### PR TITLE
LIS01A2 state machine, part 8

### DIFF
--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/Commands.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/Commands.pm
@@ -6,10 +6,10 @@ use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Constants
 
 use Exporter 'import';
 our @EXPORT = qw(
-	CMD_STEP_UNTIL_IDLE
-	CMD_STEP_UNTIL
-	CMD_SLEEP
-	CMD_SEND_MSG
+	StepUntilIdle
+	StepUntil
+	Sleep
+	SendMsg
 );
 
 use MooX::Struct Command => [
@@ -20,7 +20,7 @@ use MooX::Struct Command => [
 	},
 ];
 
-sub CMD_STEP_UNTIL_IDLE {
+sub StepUntilIdle {
 	Command->new(
 		description => 'Process events until idle',
 		code => sub {
@@ -30,7 +30,7 @@ sub CMD_STEP_UNTIL_IDLE {
 	);
 }
 
-sub CMD_STEP_UNTIL {
+sub StepUntil {
 	my ($state) = @_;
 	Command->new(
 		description => "Process events until $state",
@@ -41,7 +41,7 @@ sub CMD_STEP_UNTIL {
 	);
 }
 
-sub CMD_SLEEP {
+sub Sleep {
 	my ($duration) = @_;
 	Command->new(
 		description => "Sleep for $duration seconds",
@@ -52,7 +52,7 @@ sub CMD_SLEEP {
 	);
 }
 
-sub CMD_SEND_MSG {
+sub SendMsg {
 	my ($message) = @_;
 	Command->new(
 		description => "Send message $message",

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/Commands.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/Commands.pm
@@ -1,11 +1,67 @@
 package Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::Commands;
 # ABSTRACT: A library of commands
 
-use Const::Exporter default => [
-	CMD_STEP_UNTIL_IDLE => 'step-until-idle',
-	CMD_STEP_UNTIL     => 'step',
-	CMD_SLEEP          => 'sleep',
-	CMD_SEND_MSG       => 'send-message',
+use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Constants
+	qw(:enum_state);
+
+use Exporter 'import';
+our @EXPORT = qw(
+	CMD_STEP_UNTIL_IDLE
+	CMD_STEP_UNTIL
+	CMD_SLEEP
+	CMD_SEND_MSG
+);
+
+use MooX::Struct Command => [
+	qw( description code ),
+	run => sub {
+		my ($self, $simulator, $session) = @_;
+		$_[0]->code->( @_ );
+	},
 ];
+
+sub CMD_STEP_UNTIL_IDLE {
+	Command->new(
+		description => 'Process events until idle',
+		code => sub {
+			my ($self, $simulator, $session) = @_;
+			$session->_process_until_state( STATE_N_IDLE );
+		},
+	);
+}
+
+sub CMD_STEP_UNTIL {
+	my ($state) = @_;
+	Command->new(
+		description => "Process events until $state",
+		code => sub {
+			my ($self, $simulator, $session) = @_;
+			$session->_process_until_state( $state );
+		},
+	);
+}
+
+sub CMD_SLEEP {
+	my ($duration) = @_;
+	Command->new(
+		description => "Sleep for $duration seconds",
+		code => sub {
+			my ($self, $simulator, $session) = @_;
+			Future::IO->sleep($duration);
+		},
+	);
+}
+
+sub CMD_SEND_MSG {
+	my ($message) = @_;
+	Command->new(
+		description => "Send message $message",
+		code => sub {
+			my ($self, $simulator, $session) = @_;
+			$session->send_message( $message );
+			Future->done;
+		},
+	);
+}
 
 1;

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/Commands.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/Commands.pm
@@ -4,12 +4,15 @@ package Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::Commands;
 use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Constants
 	qw(:enum_state);
 
+use Module::Load;
+
 use Exporter 'import';
 our @EXPORT = qw(
 	StepUntilIdle
 	StepUntil
 	Sleep
 	SendMsg
+	TestTransition
 );
 
 use MooX::Struct Command => [
@@ -60,6 +63,20 @@ sub SendMsg {
 			my ($self, $simulator, $session) = @_;
 			$session->send_message( $message );
 			Future->done;
+		},
+	);
+}
+
+sub TestTransition {
+	my ($event) = @_;
+	Command->new(
+		description => "Test that the last transition was $event",
+		code => sub {
+			my ($self, $simulator, $session) = @_;
+			load Test2::V0, qw/is/;
+			Future->done(
+				is($simulator->transitions->[-1]->transition, $event, "Transition $event")
+			);
 		},
 	);
 }

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Processable.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Processable.pm
@@ -4,9 +4,9 @@ package Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Processable;
 use Mu::Role;
 use namespace::autoclean;
 
+use Devel::StrictMode;
 use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Constants
 	qw(:enum_state);
-
 use Types::Standard qw(Enum);
 
 use Future::AsyncAwait;
@@ -22,7 +22,7 @@ sub process_step {
 my $EnumState = Enum[ @ENUM_STATE ];
 async sub _process_until_state {
 	my ($self, $state) = @_;
-	$EnumState->assert_valid( $state );
+	$EnumState->assert_valid( $state ) if STRICT;
 
 	my $r_f = repeat {
 		my $f = $self->process_step

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Processable.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Processable.pm
@@ -7,6 +7,8 @@ use namespace::autoclean;
 use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Constants
 	qw(:enum_state);
 
+use Types::Standard qw(Enum);
+
 use Future::AsyncAwait;
 use Future::Utils qw(repeat);
 
@@ -17,8 +19,10 @@ sub process_step {
 	$self->step;
 }
 
+my $EnumState = Enum[ @ENUM_STATE ];
 async sub _process_until_state {
 	my ($self, $state) = @_;
+	$EnumState->assert_valid( $state );
 
 	my $r_f = repeat {
 		my $f = $self->process_step

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Simulator.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Simulator.pm
@@ -41,7 +41,7 @@ ro transitions => (
 	default => sub { [] },
 );
 
-sub BUILD {
+sub _apply_logger {
 	my ($self) = @_;
 	my $step_count = 0;
 	my $log = $self->_logger;
@@ -55,8 +55,21 @@ sub BUILD {
 			$event->state_transition,
 			$event->emitter,
 		);
+	});
+}
+
+sub _apply_transition_tracking {
+	my ($self) = @_;
+	$self->session->on( step => sub {
+		my ($event) = @_;
 		push @{ $self->transitions }, $event->state_transition;
 	});
+}
+
+sub BUILD {
+	my ($self) = @_;
+	$self->_apply_logger;
+	$self->_apply_transition_tracking;
 }
 
 sub process_commands {

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/StateMachine.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/StateMachine.t
@@ -41,7 +41,7 @@ sub show_plantuml {
 
 	if( $opt{text} ) {
 		my $txt_out = render_plantuml_to_text($plantuml);
-		print $txt_out;
+		note $txt_out;
 	}
 
 	if( $opt{png} && which('display') ) {

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-package MyTest;
+package Test::SM::SenderTimesOut;
 use lib 't/lib';
 use Test2::Roo;
 use MooX::ShortHas;

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
@@ -6,7 +6,7 @@ use Test2::Roo;
 use MooX::ShortHas;
 
 use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Constants
-	qw(:enum_state);
+	qw(:enum_state :enum_event);
 use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Message' => 'LIS01A2::Message';
 use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::TimerFactory';
 use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::Commands;
@@ -15,6 +15,7 @@ lazy local_steps => sub {
 	[
 		[ STATE_N_IDLE , SendMsg( LIS01A2::Message->create_message( 'Hello world' ) ) ],
 		[ STATE_N_IDLE , StepUntilIdle() ],
+		[ STATE_N_IDLE , TestTransition(EV_TIMED_OUT) ],
 	]
 };
 

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
@@ -13,15 +13,15 @@ use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::Commands;
 
 lazy local_steps => sub {
 	[
-		[ STATE_N_IDLE , CMD_SEND_MSG()  , LIS01A2::Message->create_message( 'Hello world' ) ],
+		[ STATE_N_IDLE , CMD_SEND_MSG( LIS01A2::Message->create_message( 'Hello world' ) ) ],
 		[ STATE_N_IDLE , CMD_STEP_UNTIL_IDLE() ],
 	]
 };
 
 lazy remote_steps => sub {
 	[
-		[ STATE_N_IDLE , CMD_STEP_UNTIL() ],
-		[ STATE_R_GOOD_FRAME, CMD_SLEEP(), TimerFactory->new->duration_sender + 1 ],
+		[ STATE_N_IDLE , CMD_STEP_UNTIL(STATE_R_GOOD_FRAME) ],
+		[ STATE_R_GOOD_FRAME, CMD_SLEEP(TimerFactory->new->duration_sender + 1) ],
 		[ STATE_R_GOOD_FRAME , CMD_STEP_UNTIL_IDLE() ],
 	]
 };

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
@@ -13,16 +13,16 @@ use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::Commands;
 
 lazy local_steps => sub {
 	[
-		[ STATE_N_IDLE , CMD_SEND_MSG( LIS01A2::Message->create_message( 'Hello world' ) ) ],
-		[ STATE_N_IDLE , CMD_STEP_UNTIL_IDLE() ],
+		[ STATE_N_IDLE , SendMsg( LIS01A2::Message->create_message( 'Hello world' ) ) ],
+		[ STATE_N_IDLE , StepUntilIdle() ],
 	]
 };
 
 lazy remote_steps => sub {
 	[
-		[ STATE_N_IDLE , CMD_STEP_UNTIL(STATE_R_GOOD_FRAME) ],
-		[ STATE_R_GOOD_FRAME, CMD_SLEEP(TimerFactory->new->duration_sender + 1) ],
-		[ STATE_R_GOOD_FRAME , CMD_STEP_UNTIL_IDLE() ],
+		[ STATE_N_IDLE , StepUntil(STATE_R_GOOD_FRAME) ],
+		[ STATE_R_GOOD_FRAME, Sleep(TimerFactory->new->duration_sender + 1) ],
+		[ STATE_R_GOOD_FRAME , StepUntilIdle() ],
 	]
 };
 

--- a/t/lib/Test/SessionSim.pm
+++ b/t/lib/Test/SessionSim.pm
@@ -24,6 +24,8 @@ use IO::Async::Timer::Periodic;
 use Log::Any::Adapter;
 use Log::Any::Adapter::Screen ();
 
+use Log::Any qw($log);
+
 lazy loop => sub {
 	my $loop = IO::Async::Loop->new;
 };
@@ -76,7 +78,7 @@ test "Simulate" => sub {
 	my $self = shift;
 	Log::Any::Adapter->set( {
 		lexically => \my $lex,
-		#category => qr/^main$|^Epidermis::Protocol::CLSI::LIS::LIS01A2::Client/
+		#category => qr/^main$|^Epidermis::Protocol::CLSI::LIS::LIS01A2::Session/
 		},
 		'Screen', min_level => 'trace', formatter => sub { $_[1] =~ s/^/  # LOG: /mgr } ) if $ENV{TEST_VERBOSE};
 
@@ -86,7 +88,8 @@ test "Simulate" => sub {
 		interval => 1,
 		on_tick => sub {
 			state $tick = 0;
-			print "Timer: @{[ ++$tick ]}\n";
+			$log->tracef("Timer: %d", ++$tick)
+				 if $log->is_trace;
 		},
 	);
 	$loop->later(sub {

--- a/t/lib/Test/SessionSim.pm
+++ b/t/lib/Test/SessionSim.pm
@@ -102,9 +102,6 @@ test "Simulate" => sub {
 	});
 
 	$loop->run;
-
-	is $self->local->transitions->[-1]->transition, EV_TIMED_OUT, 'timed out';
-	is $self->local->transitions->[-1]->to, STATE_N_IDLE, 'idle';
 };
 
 1;


### PR DESCRIPTION
- Use coerce to set up Drivable role
- Check type of params is a state
- Extract out logging and transition tracking to methods
- Define commands with coderefs instead of constants
- Use Upper Camel Case for the command names
- Add TestTransition command
- Misc test output clean up
