### PR TITLE
LIS01A2 state machine, part 9

### DIFF
--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Frame.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Frame.pm
@@ -21,10 +21,8 @@ use Epidermis::Protocol::CLSI::LIS::Constants qw(
 	CR LF
 );
 
-use constant {
-	FRAME_TYPE_INTERMEDIATE => 'intermediate',
-	FRAME_TYPE_END => 'end',
-};
+use Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame::Constants
+	qw(:frame_type);
 
 use Const::Fast;
 

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Frame.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Frame.pm
@@ -67,8 +67,15 @@ has frame_number => (
 
 lazy next_frame_number => sub {
 	my ($self) = @_;
-	($self->frame_number + 1) % 8;
+	$self->_compute_next_frame_number(
+		$self->frame_number
+	);
 };
+
+sub _compute_next_frame_number {
+	my ($class, $frame_number) = @_;
+	($frame_number + 1) % 8;
+}
 
 =attr content
 

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Frame/Constants.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Frame/Constants.pm
@@ -1,0 +1,19 @@
+package Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame::Constants;
+# ABSTRACT: Constants for frames
+
+our @_ENUM_FRAME_TYPE = qw(
+	FRAME_TYPE_INTERMEDIATE
+	FRAME_TYPE_END
+);
+use Const::Exporter;
+Const::Exporter->import(
+frame_type => [
+	(
+	our %_ENUM_FRAME_TYPE_VALUES = map {
+		$_ => lc( $_ =~ s/^FRAME_TYPE_//r )
+	} @_ENUM_FRAME_TYPE,
+	),
+	'@ENUM_FRAME_TYPE' => [ values %_ENUM_FRAME_TYPE_VALUES ],
+]);
+
+1;

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Message.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Message.pm
@@ -10,6 +10,8 @@ use Types::Standard qw(ArrayRef InstanceOf);
 
 use Epidermis::Protocol::CLSI::LIS::Constants qw(LIS01A2_FIRST_FRAME_NUMBER);
 use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame';
+use Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame::Constants
+	qw(:frame_type);
 
 use constant FRAME_DATA_MAX_LENGTH => 240;
 
@@ -83,7 +85,9 @@ sub create_message {
 		$message->add_frame( my $frame = Frame->new(
 			frame_number => $frame_number,
 			content => $content,
-			type => ( @frame_data ? 'intermediate' : 'end' ),
+			type => ( @frame_data
+				? FRAME_TYPE_INTERMEDIATE
+				: FRAME_TYPE_END ),
 		));
 
 		$frame_number = $frame->next_frame_number;

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Message.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Message.pm
@@ -96,6 +96,27 @@ sub create_message {
 	return $message;
 }
 
+sub create_message_from_frames {
+	# NOTE used to renumber frames
+	my ($class, $frames, $message_args ) = @_;
+
+	$message_args //= {};
+
+	my $self = $class->new( $message_args );
+	my $frame_num = $self->start_frame_number;
+	for my $frame_idx (0..@$frames-1) {
+		my $frame = Frame->new(
+			frame_number => $frame_num,
+			content => $frames->[$frame_idx]->content,
+			type => $frames->[$frame_idx]->type,
+		);
+		$self->add_frame( $frame );
+		$frame_num = $frame->next_frame_number;
+	}
+
+	return $self;
+}
+
 sub message_data {
 	my ($self) = @_;
 	join "", map { $_->content } @{ $self->frames };

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/Commands.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/Commands.pm
@@ -14,8 +14,11 @@ our @EXPORT = qw(
 	StepUntil
 	SleepPlus
 	SendMsg
+	SendMsgWithSingleFrame
 	TestTransition
 );
+
+use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Message' => 'LIS01A2::Message';
 
 use MooX::Struct Command => [
 	qw( description code ),
@@ -72,6 +75,18 @@ sub SendMsg {
 	my ($message) = @_;
 	Command->new(
 		description => "Send message $message",
+		code => sub {
+			my ($self, $simulator, $session) = @_;
+			$session->send_message( $message );
+			Future->done;
+		},
+	);
+}
+
+sub SendMsgWithSingleFrame {
+	my $message = LIS01A2::Message->create_message( 'Hello world' );
+	Command->new(
+		description => "Send single frame message",
 		code => sub {
 			my ($self, $simulator, $session) = @_;
 			$session->send_message( $message );

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/Commands.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/Commands.pm
@@ -15,10 +15,11 @@ our @EXPORT = qw(
 	SleepPlus
 	SendMsg
 	SendMsgWithSingleFrame
+	SendMsgWithMultipleFrames
 	TestTransition
 );
 
-use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Message' => 'LIS01A2::Message';
+use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::TestMessages';
 
 use MooX::Struct Command => [
 	qw( description code ),
@@ -84,14 +85,20 @@ sub SendMsg {
 }
 
 sub SendMsgWithSingleFrame {
-	my $message = LIS01A2::Message->create_message( 'Hello world' );
+	my $message = TestMessages->new->single_frame;
 	Command->new(
 		description => "Send single frame message",
-		code => sub {
-			my ($self, $simulator, $session) = @_;
-			$session->send_message( $message );
-			Future->done;
-		},
+		code => SendMsg( $message )->code,
+	);
+}
+
+sub SendMsgWithMultipleFrames {
+	my ($count) = @_;
+	$count = 1 unless defined $count;
+	my $message = TestMessages->new->multiple_frames($count);
+	Command->new(
+		description => "Send message with $count frames",
+		code => SendMsg( $message )->code,
 	);
 }
 

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/TestMessages.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Driver/TestMessages.pm
@@ -1,0 +1,40 @@
+package Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::TestMessages;
+# ABSTRACT: Messages for testing
+
+use Mu;
+
+use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Message' => 'LIS01A2::Message';
+use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame' => 'LIS01A2::Frame';
+use Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame::Constants
+	qw(:frame_type);
+
+use Epidermis::Protocol::CLSI::LIS::Constants qw(
+	LIS01A2_FIRST_FRAME_NUMBER
+);
+
+lazy single_frame => sub {
+	my $message = LIS01A2::Message->create_message( 'Hello world' );
+};
+
+sub multiple_frames {
+	my ($self, $count) = @_;
+	$count = 2 unless $count;
+
+	my @frames;
+	for my $frame_id (1..$count) {
+		my $frame = LIS01A2::Frame->new(
+			content => "frame $frame_id",
+			type => $frame_id == $count
+				? FRAME_TYPE_END
+				: FRAME_TYPE_INTERMEDIATE ,
+		);
+		push @frames, $frame;
+	}
+
+	my $message = LIS01A2::Message
+		->create_message_from_frames(\@frames);
+
+	$message;
+}
+
+1;

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/MessageQueue.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/MessageQueue.pm
@@ -5,6 +5,8 @@ use strict;
 use warnings;
 use namespace::autoclean;
 
+use Future;
+
 use Types::Standard qw(InstanceOf Str);
 use Epidermis::Protocol::CLSI::LIS::Types qw(FrameNumber);
 
@@ -43,7 +45,7 @@ use MooX::Struct -retain,
 			) ],
 		],
 
-		_frame_index => [ default => sub { 0 } ],
+		_frame_index => [ is => 'rw', default => sub { 0 } ],
 
 		get_current_frame => sub {
 			my ($self) = @_;

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/MessageQueue.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/MessageQueue.pm
@@ -32,8 +32,8 @@ use MooX::Struct -retain,
 			isa => InstanceOf['Epidermis::Protocol::CLSI::LIS::LIS01A2::Message'],
 			lazy => 1, default => sub {
 				my ($self) = @_;
-				Epidermis::Protocol::CLSI::LIS::LIS01A2::Message->create_message(
-					$self->message_item->message->message_data,
+				Epidermis::Protocol::CLSI::LIS::LIS01A2::Message->create_message_from_frames(
+					$self->message_item->message->frames,
 					{ start_frame_number => $self->initial_fn },
 				);
 			},

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/MessageQueue.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/MessageQueue.pm
@@ -10,14 +10,14 @@ use Future;
 use Types::Standard qw(InstanceOf Str);
 use Epidermis::Protocol::CLSI::LIS::Types qw(FrameNumber);
 
-use Epidermis::Protocol::CLSI::LIS::LIS01A2::Message;
-use Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame;
+use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Message';
+use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame';
 
 use MooX::Struct -retain,
 	MessageQueueItem => [
 		message => [
 			required => 1,
-			isa => InstanceOf['Epidermis::Protocol::CLSI::LIS::LIS01A2::Message'],
+			isa => InstanceOf[Message],
 		],
 		future =>  [
 			isa => InstanceOf['Future'],
@@ -31,10 +31,10 @@ use MooX::Struct -retain,
 		message_item => [ isa => MessageQueueItem->TYPE_TINY, required => 1 ],
 		initial_fn => [ isa => FrameNumber, required => 1 ],
 		message => [
-			isa => InstanceOf['Epidermis::Protocol::CLSI::LIS::LIS01A2::Message'],
+			isa => InstanceOf[Message],
 			lazy => 1, default => sub {
 				my ($self) = @_;
-				Epidermis::Protocol::CLSI::LIS::LIS01A2::Message->create_message_from_frames(
+				Message->create_message_from_frames(
 					$self->message_item->message->frames,
 					{ start_frame_number => $self->initial_fn },
 				);
@@ -68,10 +68,10 @@ use MooX::Struct -retain,
 	ReceivableMessage => [
 		initial_fn => [ isa => FrameNumber, required => 1 ],
 		message => [
-			isa => InstanceOf['Epidermis::Protocol::CLSI::LIS::LIS01A2::Message'],
+			isa => InstanceOf[Message],
 			lazy => 1, default => sub {
 				my ($self) = @_;
-				Epidermis::Protocol::CLSI::LIS::LIS01A2::Message->new(
+				Message->new(
 					start_frame_number => $self->initial_fn,
 				);
 			},
@@ -82,7 +82,7 @@ use MooX::Struct -retain,
 		],
 		_current_frame => [
 			is => 'rw',
-			isa => InstanceOf['Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame'],
+			isa => InstanceOf[Frame],
 		],
 
 		set_current_frame_data => sub {
@@ -94,7 +94,7 @@ use MooX::Struct -retain,
 		process_current_frame_data => sub {
 			my ($self) = @_;
 
-			my $frame = Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame->parse_frame_data( $self->_current_frame_data );
+			my $frame = Frame->parse_frame_data( $self->_current_frame_data );
 			$self->message->add_frame( $frame );
 		},
 	];

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Process/StepEventEmitter.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Process/StepEventEmitter.pm
@@ -11,13 +11,13 @@ with qw(Beam::Emitter);
 around process_step => sub {
 	my ($orig, $self, @args) = @_;
 	$orig->($self, @args)
-		->followed_by(sub {
-			my ($f1) = @_;
+		->transform( done => sub {
+			my ($result) = @_;
 			$self->emit( 'step',
 				class => StepEvent,
-				state_transition => $f1->get,
+				state_transition => $result,
 			);
-			Future->done( $f1->get );
+			return $result;
 		});
 };
 

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Processable.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Processable.pm
@@ -34,7 +34,7 @@ async sub _process_until_state {
 				Future->done;
 			});
 	} until => sub {
-		$self->session_state eq $state
+		$_[0]->is_failed || $self->session_state eq $state
 	};
 
 	await $r_f;

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Role/StateMachine.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Role/StateMachine.pm
@@ -80,7 +80,7 @@ async sub step {
 			->set_label($action)
 	} @actions)->set_label( LIS_DEBUG ? "actions: @actions" : 'actions' );
 
-	await $actions_done->followed_by( sub { $self->_reset_after_step; Future->done->set_label('reset after step') } );
+	await $actions_done->then( sub { $self->_reset_after_step; Future->done->set_label('reset after step') } );
 
 	return StateTransition[
 		$transition_data->{id},

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Data.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Data.pm
@@ -74,13 +74,13 @@ sub _process_frame_data {
 		->set_label('process frame data');
 	if( LIS_DEBUG && $self->_logger->is_trace) {
 		$f = $f->then_with_f(sub {
-			my ($f, $result) = @_;
+			my ($f1, $result) = @_;
 			$self->_logger->trace( $self->_logger_name_prefix . "Processing frame data: "
 				.  ( $result->{is_good_frame}
 					? "Good frame"
 					: "Bad frame; Error: $result->{error}" )
 			);
-			$f;
+			$f1;
 		});
 	}
 	$self->_process_frame_data_future( $f );

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Data.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Data.pm
@@ -73,14 +73,14 @@ sub _process_frame_data {
 		} or { is_good_frame => false, error => $@ })
 		->set_label('process frame data');
 	if( LIS_DEBUG && $self->_logger->is_trace) {
-		$f = $f->then(sub {
-			my ($result) = @_;
+		$f = $f->then_with_f(sub {
+			my ($f, $result) = @_;
 			$self->_logger->trace( $self->_logger_name_prefix . "Processing frame data: "
 				.  ( $result->{is_good_frame}
 					? "Good frame"
 					: "Bad frame; Error: $result->{error}" )
 			);
-			Future->done( $result )
+			$f;
 		});
 	}
 	$self->_process_frame_data_future( $f );

--- a/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Simulator.pm
+++ b/lib/Epidermis/Protocol/CLSI/LIS/LIS01A2/Simulator.pm
@@ -88,7 +88,7 @@ sub process_commands {
 		} else {
 			Future->die( "unexpected state" );
 		}
-	} foreach => $events;
+	} foreach => $events, while => sub { $_[0]->is_done };
 }
 
 1;

--- a/maint/generate-sm-cov.pl
+++ b/maint/generate-sm-cov.pl
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use File::Find::Rule;
+use Path::Tiny;
+use File::Symlink::Relative;
+
+sub main {
+	my $coverage_dir = path( $FindBin::Bin,
+		'..',
+		't/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover'
+	);
+	my $skel = $coverage_dir->child('test-rel.t.skel');
+	die "Skeleton file missing" unless -f $skel;
+
+	my @files = File::Find::Rule
+		->file
+		->name( '*.data.pl' )
+		->in( $coverage_dir );
+
+	symlink_r $skel, $_ for map { $_ =~ s/\Q.data.pl\E$/.t/r } @files;
+}
+
+main;

--- a/maint/generate-sm-cov.pl
+++ b/maint/generate-sm-cov.pl
@@ -20,6 +20,7 @@ sub main {
 		->name( '*.data.pl' )
 		->in( $coverage_dir );
 
+	chmod 0644, @files;
 	symlink_r $skel, $_ for map { $_ =~ s/\Q.data.pl\E$/.t/r } @files;
 }
 

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Frame.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Frame.t
@@ -1,9 +1,9 @@
 #!/usr/bin/env perl
 
 use Test2::V0;
-plan tests => 5;
+plan tests => 6;
 
-use Epidermis::Protocol::CLSI::LIS::Constants qw(STX ETX ETB);
+use Epidermis::Protocol::CLSI::LIS::Constants qw(STX ETX ETB CR LF);
 use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame';
 
 use Data::Hexdumper ();
@@ -40,6 +40,19 @@ subtest "Check frame creation" => sub {
 
 	is Frame->new( content => "A|B|C|D\x0d" )->checksum,
 		'BF', 'Got checksum';
+};
+
+subtest "Parse good frame data" => sub {
+	# Example frame via <https://hendricksongroup.com/code_003.aspx>
+	my $frame = Frame->parse_frame_data( join "", (
+		STX,
+		"5R|2|^^^1.0000+950+1.0|15|||^5^||V||34001637|20080516153540|20080516153602|34001637\x0d",
+		ETX,
+		'3D', # checksum
+		CR, LF
+	));
+	ok $frame->is_end, 'parsed end frame';
+	is $frame->checksum, '3D', 'checksum';
 };
 
 subtest "Parsing error detection" => sub {

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Frame.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Frame.t
@@ -1,10 +1,13 @@
 #!/usr/bin/env perl
 
 use Test2::V0;
-plan tests => 4;
+plan tests => 5;
 
-use Epidermis::Protocol::CLSI::LIS::Constants qw(STX);
+use Epidermis::Protocol::CLSI::LIS::Constants qw(STX ETX ETB);
 use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Frame';
+
+use Data::Hexdumper ();
+use boolean;
 
 subtest "Check frame creation" => sub {
 	my $content = "test";
@@ -113,6 +116,38 @@ subtest "Incorrect frame number" => sub {
 			frame_number => 8,
 		);
 	}, qr/FrameNumber/;
+};
+
+subtest "Frame type" => sub {
+	my $test_text = "test";
+
+	subtest "End frame" => sub {
+		my $end_test_frame = Frame->new(
+			type => 'end',
+			content => $test_text );
+		is substr( $end_test_frame->frame_data, -5, 1 ), ETX,
+			'end frame has ETX';
+		ok Frame->parse_frame_data($end_test_frame->frame_data)
+			->is_end,
+			'end frame round-trips as end frame';
+		note "End frame data: ", Data::Hexdumper::hexdump(
+			data => $end_test_frame->frame_data,
+			suppress_warnings => true );
+	};
+
+	subtest "Intermediate frame" => sub {
+		my $int_test_frame = Frame->new(
+			type => 'intermediate',
+			content => $test_text );
+		is substr( $int_test_frame->frame_data, -5, 1 ), ETB,
+			'intermediate frame has ETB';
+		ok Frame->parse_frame_data($int_test_frame->frame_data)
+			->is_intermediate,
+			'intermediate frame round-trips as intermediate frame';
+		note "Intermediate frame data: ", Data::Hexdumper::hexdump(
+			data => $int_test_frame->frame_data,
+			suppress_warnings => true );
+	};
 };
 
 subtest "Frame number sequence" => sub {

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
@@ -7,13 +7,11 @@ use MooX::ShortHas;
 
 use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Constants
 	qw(:enum_state :enum_event);
-use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Message' => 'LIS01A2::Message';
-use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::TimerFactory';
 use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::Commands;
 
 lazy local_steps => sub {
 	[
-		[ STATE_N_IDLE , SendMsg( LIS01A2::Message->create_message( 'Hello world' ) ) ],
+		[ STATE_N_IDLE , SendMsgWithSingleFrame() ],
 		[ STATE_N_IDLE , StepUntilIdle() ],
 		[ STATE_N_IDLE , TestTransition(EV_TIMED_OUT) ],
 	]

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
@@ -12,7 +12,6 @@ use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::TimerFactory';
 use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::Commands;
 
 lazy local_steps => sub {
-	my ($self) = @_;
 	[
 		[ STATE_N_IDLE , SendMsg( LIS01A2::Message->create_message( 'Hello world' ) ) ],
 		[ STATE_N_IDLE , StepUntilIdle() ],
@@ -21,10 +20,9 @@ lazy local_steps => sub {
 };
 
 lazy remote_steps => sub {
-	my ($self) = @_;
 	[
 		[ STATE_N_IDLE , StepUntil(STATE_R_GOOD_FRAME) ],
-		[ STATE_R_GOOD_FRAME, Sleep($self->timer_factory->duration_sender + 1) ],
+		[ STATE_R_GOOD_FRAME, SleepPlus('sender') ],
 		[ STATE_R_GOOD_FRAME , StepUntilIdle() ],
 	]
 };

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover.t
@@ -12,6 +12,7 @@ use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::TimerFactory';
 use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::Commands;
 
 lazy local_steps => sub {
+	my ($self) = @_;
 	[
 		[ STATE_N_IDLE , SendMsg( LIS01A2::Message->create_message( 'Hello world' ) ) ],
 		[ STATE_N_IDLE , StepUntilIdle() ],
@@ -20,9 +21,10 @@ lazy local_steps => sub {
 };
 
 lazy remote_steps => sub {
+	my ($self) = @_;
 	[
 		[ STATE_N_IDLE , StepUntil(STATE_R_GOOD_FRAME) ],
-		[ STATE_R_GOOD_FRAME, Sleep(TimerFactory->new->duration_sender + 1) ],
+		[ STATE_R_GOOD_FRAME, Sleep($self->timer_factory->duration_sender + 1) ],
 		[ STATE_R_GOOD_FRAME , StepUntilIdle() ],
 	]
 };

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/send-message-multi-frame.data.pl
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/send-message-multi-frame.data.pl
@@ -1,0 +1,16 @@
+{
+local =>
+	[
+		[ STATE_N_IDLE , SendMsgWithMultipleFrames(3) ],
+		[ STATE_N_IDLE , StepUntilIdle() ],
+		[ STATE_N_IDLE , TestTransition(EV_TRANSFER_DONE) ],
+	],
+remote =>
+	[
+		[ STATE_N_IDLE , StepUntil(STATE_R_GOOD_FRAME) ],
+		[ STATE_R_GOOD_FRAME , StepUntil(STATE_R_GOOD_FRAME) ],
+		[ STATE_R_GOOD_FRAME , StepUntil(STATE_R_GOOD_FRAME) ],
+		[ STATE_R_GOOD_FRAME , StepUntilIdle() ],
+	]
+
+}

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/send-message-multi-frame.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/send-message-multi-frame.t
@@ -1,0 +1,1 @@
+test-rel.t.skel

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/send-message-single-frame.data.pl
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/send-message-single-frame.data.pl
@@ -1,0 +1,14 @@
+{
+local =>
+	[
+		[ STATE_N_IDLE , SendMsgWithSingleFrame() ],
+		[ STATE_N_IDLE , StepUntilIdle() ],
+		[ STATE_N_IDLE , TestTransition(EV_TRANSFER_DONE) ],
+	],
+remote =>
+	[
+		[ STATE_N_IDLE , StepUntil(STATE_R_GOOD_FRAME) ],
+		[ STATE_R_GOOD_FRAME , StepUntilIdle() ],
+	]
+
+}

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/send-message-single-frame.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/send-message-single-frame.t
@@ -1,0 +1,1 @@
+test-rel.t.skel

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/sender-times-out.data.pl
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/sender-times-out.data.pl
@@ -1,0 +1,15 @@
+{
+local =>
+	[
+		[ STATE_N_IDLE , SendMsgWithSingleFrame() ],
+		[ STATE_N_IDLE , StepUntilIdle() ],
+		[ STATE_N_IDLE , TestTransition(EV_TIMED_OUT) ],
+	],
+remote =>
+	[
+		[ STATE_N_IDLE , StepUntil(STATE_R_GOOD_FRAME) ],
+		[ STATE_R_GOOD_FRAME, SleepPlus('sender') ],
+		[ STATE_R_GOOD_FRAME , StepUntilIdle() ],
+	]
+
+}

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/sender-times-out.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/sender-times-out.t
@@ -1,5 +1,1 @@
-#!/usr/bin/env perl
-use lib 't/lib';
-use Test::SessionSim::FromDataFileRel;
-Test::SessionSim::FromDataFileRel->run_tests;
-done_testing;
+test-rel.t.skel

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/sender-times-out.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/sender-times-out.t
@@ -1,0 +1,6 @@
+#!/usr/bin/env perl
+use lib 't/lib';
+use Test2::V0;
+use Test::SessionSim::FromDataFileRel;
+Test::SessionSim::FromDataFileRel->run_tests;
+done_testing;

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/sender-times-out.t
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/sender-times-out.t
@@ -1,6 +1,5 @@
 #!/usr/bin/env perl
 use lib 't/lib';
-use Test2::V0;
 use Test::SessionSim::FromDataFileRel;
 Test::SessionSim::FromDataFileRel->run_tests;
 done_testing;

--- a/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/test-rel.t.skel
+++ b/t/Epidermis/Protocol/CLSI/LIS/LIS01A2/Session/Transition/Cover/test-rel.t.skel
@@ -1,0 +1,5 @@
+#!/usr/bin/env perl
+use lib 't/lib';
+use Test::SessionSim::FromDataFileRel;
+Test::SessionSim::FromDataFileRel->run_tests;
+done_testing;

--- a/t/lib/Test/SessionSim.pm
+++ b/t/lib/Test/SessionSim.pm
@@ -15,6 +15,9 @@ use Future::IO::Impl::IOAsync;
 
 use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Session';
 use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Simulator';
+use aliased 'Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::TimerFactory';
+
+use aliased 'Test::TimerFactory::Factor';
 
 use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Constants
 	qw(:enum_system :enum_state :enum_event);
@@ -34,6 +37,15 @@ lazy connection => sub {
 	my $test_conn = Connection->build_test_connection;
 };
 
+lazy timer_factory => sub {
+	Moo::Role->create_class_with_roles(
+		TimerFactory,
+		Factor
+	)->new(
+		factor => 1/8,
+	);
+};
+
 lazy local => sub {
 	my ($self) = @_;
 	Simulator->new(
@@ -41,6 +53,7 @@ lazy local => sub {
 			connection => $self->connection->connection0,
 			session_system => SYSTEM_COMPUTER,
 			name => 'cli',
+			_timer_factory => $self->timer_factory,
 		),
 		commands => $self->local_steps,
 	);
@@ -53,6 +66,7 @@ lazy remote => sub {
 			connection => $self->connection->connection1,
 			session_system => SYSTEM_INSTRUMENT,
 			name => 'sim',
+			_timer_factory => $self->timer_factory,
 		),
 		commands => $self->remote_steps,
 	);

--- a/t/lib/Test/SessionSim/FromDataFile.pm
+++ b/t/lib/Test/SessionSim/FromDataFile.pm
@@ -1,0 +1,27 @@
+package Test::SessionSim::FromDataFile;
+# ABSTRACT: Read data file to load testing steps
+
+use Test2::Roo;
+use MooX::ShortHas;
+use Path::Tiny;
+
+use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Constants
+	qw(:enum_state :enum_event);
+use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::Commands;
+
+ro 'data_path';
+
+lazy _data => sub {
+	do "". path($_[0]->data_path)->absolute;
+};
+
+lazy local_steps => sub { $_[0]->_data->{local}; };
+lazy remote_steps => sub { $_[0]->_data->{remote}; };
+
+before setup => sub {
+	note "Testing steps: ", $_[0]->data_path;
+};
+
+with 'Test::SessionSim';
+
+1;

--- a/t/lib/Test/SessionSim/FromDataFile.pm
+++ b/t/lib/Test/SessionSim/FromDataFile.pm
@@ -1,6 +1,7 @@
 package Test::SessionSim::FromDataFile;
 # ABSTRACT: Read data file to load testing steps
 
+use Test2::V0;
 use Test2::Roo;
 use MooX::ShortHas;
 use Path::Tiny;
@@ -10,6 +11,13 @@ use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Constants
 use Epidermis::Protocol::CLSI::LIS::LIS01A2::Session::Driver::Commands;
 
 ro 'data_path';
+
+use Import::Into;
+
+sub import {
+	my $caller = scalar caller;
+	Test2::V0->import::into($caller);
+}
 
 lazy _data => sub {
 	do "". path($_[0]->data_path)->absolute;

--- a/t/lib/Test/SessionSim/FromDataFileRel.pm
+++ b/t/lib/Test/SessionSim/FromDataFileRel.pm
@@ -1,0 +1,9 @@
+package Test::SessionSim::FromDataFileRel;
+# ABSTRACT: Read data from file relative to test file
+
+use Mu;
+extends 'Test::SessionSim::FromDataFile';
+
+lazy data_path => sub { $0 =~ s/\.t$/.data.pl/r };
+
+1;

--- a/t/lib/Test/TimerFactory/Factor.pm
+++ b/t/lib/Test/TimerFactory/Factor.pm
@@ -1,0 +1,28 @@
+package Test::TimerFactory::Factor;
+# ABSTRACT: Role to transform the duration of timers
+
+use Mu::Role;
+use MooX::Should;
+use Types::Common::Numeric qw(PositiveNum);
+
+has factor => (
+	is => 'rw',
+	should => PositiveNum,
+	default => sub { 1 },
+);
+
+for my $duration_attr (qw(
+	duration_receiver
+	duration_sender
+	duration_contention_instrument
+	duration_contention_computer
+	duration_busy
+)) {
+	around $duration_attr => sub {
+		my ( $orig, $self, @args ) = @_;
+
+		$self->$orig(@args) * $self->factor;
+	};
+}
+
+1;


### PR DESCRIPTION
- Add test role to transform duration of timers
- Sleep using duration name instead of explicit number
- Add command to send a message with only one frame
- Move frame types to separate constants module
- Extract frame number computation to private `classmethod`
- Test parsing example frame
- Turn state machine coverage into data-driven tests
- Use `Import::Into` to simplify test file
- Use symlink for test script
- Script that symlinks to test skeleton
- Test that sends single frame
- Check repeat for failed futures
- Keep data files as `0644` mode
- Use frame type constants
- Use `transform` and `else_with_f` to propagate failure
- Add `create_message_from_frames` to renumber frames
- Add helpers to create test messages
- Make frame index attribute `rw`
- Modify some sequencing futures
- Test sending multi-frame message
